### PR TITLE
Use a new instance of Material each time a villager is instantiated

### DIFF
--- a/Assets/Scripts/Behaviours/Characters/VillagerAppearanceBehaviour.cs
+++ b/Assets/Scripts/Behaviours/Characters/VillagerAppearanceBehaviour.cs
@@ -73,7 +73,7 @@ namespace BWW.Behaviours.Characters
 
          SkinnedMeshRenderer l_renderer = GetComponentInChildren<SkinnedMeshRenderer>();
 
-         Material l_material = l_renderer.sharedMaterial;
+         Material l_material = new Material(l_renderer.sharedMaterial);
 
          l_material.SetTexture(m_sShaderTexturePropertyName, l_text);
 


### PR DESCRIPTION
Closes #34 

**Change:**
- Make a new material instance for the new spawned villager